### PR TITLE
Expose websocket.Dialer buffer size configuration via optSetter - AGENT-1250

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -92,6 +92,15 @@ func WebsocketNetDialContext(dialContext func(ctx context.Context, network strin
 	}
 }
 
+// WebsocketDialBuffers sets the websocket Dialer's Read and Write buffer sizes in bytes
+func WebsocketDialBuffers(readBufferSize, writeBufferSize int) optSetter {
+	return func(f *Forwarder) error {
+		f.websocketDialer.ReadBufferSize = readBufferSize
+		f.websocketDialer.WriteBufferSize = writeBufferSize
+		return nil
+	}
+}
+
 // ErrorHandler is a functional argument that sets error handler of the server.
 func ErrorHandler(h utils.ErrorHandler) optSetter {
 	return func(f *Forwarder) error {


### PR DESCRIPTION
As implemented the oxy Forwarder doesn't expose the websocket Dialer struct. This change allows modifying the websocket Dialer's read and write buffer size via an optSetter function.

Once merged this will be tagged as version `1.4.2-sigsci.1`